### PR TITLE
replaced call to os.genenv 'HOME'

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -171,7 +171,7 @@ vim.opt.wrap = false
 
 vim.opt.swapfile = false
 vim.opt.backup = false
-vim.opt.undodir = os.getenv 'HOME' .. '/.vim/undodir'
+vim.opt.undodir = vim.fn.expand '~/.vim/undodir'
 vim.opt.undofile = true
 
 -- Set highlight on search, but clear on pressing <Esc> in normal mode


### PR DESCRIPTION
with vim.fn.expand '~/' because
it works on both Windows and Linux

